### PR TITLE
Remove old Python 2 support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changes
 =======
 
+0.4.1 (2021-06-22)
+------------------
+
+* Drop Python 2 support.
+
+0.4.0 (2021-06-21)
+------------------
+
+* Add pyproject.toml and use setup.cfg for build configuration.
+* Update to newer package requirements.
+* Change code to work with newer SKLearn versions.
+* Simplify Tox configuration
+
 0.3.6 (2017-06-22)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -36,5 +36,5 @@ Documentation can be found `here <https://sklearn-crfsuite.readthedocs.io>`_.
 ----
 
 .. image:: https://hyperiongray.s3.amazonaws.com/define-hg.svg
-	:target: https://www.hyperiongray.com/?pk_campaign=github&pk_kwd=sklearn-crfsuite
-	:alt: define hyperiongray
+    :target: https://www.hyperiongray.com/?pk_campaign=github&pk_kwd=sklearn-crfsuite
+    :alt: define hyperiongray

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # sklearn-crfsuite documentation build configuration file, created by
 # sphinx-quickstart on Fri Nov 27 03:50:38 2015.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers =
 install_requires =
     python-crfsuite ~= 0.9.7
     scikit-learn >= 0.20.0
-    six
     tabulate
     tqdm
 packages =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
 [options]
 install_requires =
     python-crfsuite ~= 0.9.7
-    scikit-learn >= 0.20.0
+    scikit-learn >= 0.20.0,<1.0
     tabulate
     tqdm
 packages =

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [metadata]
 name = sklearn-crfsuite
-version = 0.4.0
+version = 0.4.1
 author = Mikhail Korobov
 author_email = kmike84@gmail.com
 description = CRFSuite (python-crfsuite) wrapper which provides interface similar to scikit-learn

--- a/sklearn_crfsuite/__init__.py
+++ b/sklearn_crfsuite/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from .estimator import CRF

--- a/sklearn_crfsuite/_fileresource.py
+++ b/sklearn_crfsuite/_fileresource.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import os
 import tempfile
 
@@ -11,12 +9,14 @@ class FileResource(object):
     attribute; when pickling, the contents of this file is pickled;
     when unpickling, a new temp file is created; temp files are auto-deleted.
     """
+
     def __init__(self, filename=None, keep_tempfiles=False, suffix='', prefix=''):
         self.name = filename
         self.auto = filename is None
         self.keep_tempfiles = keep_tempfiles
         self.suffix = suffix
         self.prefix = prefix
+        self.fd = None
 
     def ensure_name(self):
         """ Ensure that a filename is available """
@@ -74,4 +74,3 @@ class FileResource(object):
             self.ensure_name()
             with open(self.name, 'wb') as f:
                 f.write(data)
-

--- a/sklearn_crfsuite/compat.py
+++ b/sklearn_crfsuite/compat.py
@@ -1,5 +1,5 @@
 """
-allow to build docs without scikit-learn installed
+allow building docs without scikit-learn installed
 """
 
 try:

--- a/sklearn_crfsuite/compat.py
+++ b/sklearn_crfsuite/compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 try:
     from sklearn.base import BaseEstimator
 except ImportError:

--- a/sklearn_crfsuite/compat.py
+++ b/sklearn_crfsuite/compat.py
@@ -1,3 +1,7 @@
+"""
+allow to build docs without scikit-learn installed
+"""
+
 try:
     from sklearn.base import BaseEstimator
 except ImportError:

--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -323,7 +323,7 @@ class CRF(BaseEstimator):
             if self.verbose:
                 print("")
 
-        trainer.train(self.modelfile.name, int_holdout=(-1 if X_dev is None else 1))
+        trainer.train(self.modelfile.name, holdout=(-1 if X_dev is None else 1))
         self.training_log_ = trainer.logparser
         return self
 

--- a/sklearn_crfsuite/estimator.py
+++ b/sklearn_crfsuite/estimator.py
@@ -1,18 +1,14 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
-from six.moves import zip
-from tqdm import tqdm
 import pycrfsuite
+from tqdm import tqdm
 
 from sklearn_crfsuite._fileresource import FileResource
-from sklearn_crfsuite.trainer import LinePerIterationTrainer
 from sklearn_crfsuite.compat import BaseEstimator
+from sklearn_crfsuite.trainer import LinePerIterationTrainer
 
 
 class CRF(BaseEstimator):
     """
-    python-crfsuite wrapper with interface siimlar to scikit-learn.
+    python-crfsuite wrapper with interface similar to scikit-learn.
     It allows to use a familiar fit/predict interface and scikit-learn
     model selection utilities (cross-validation, hyperparameter optimization).
 
@@ -207,9 +203,9 @@ class CRF(BaseEstimator):
         is to use pickle (or its alternatives like joblib).
 
     """
+
     def __init__(self,
                  algorithm=None,
-
                  min_freq=None,
                  all_possible_states=None,
                  all_possible_transitions=None,
@@ -233,7 +229,6 @@ class CRF(BaseEstimator):
                  averaging=None,
                  variance=None,
                  gamma=None,
-
                  verbose=False,
                  model_filename=None,
                  keep_tempfiles=False,
@@ -263,7 +258,6 @@ class CRF(BaseEstimator):
         self.averaging = averaging
         self.variance = variance
         self.gamma = gamma
-
         self.model_filename = model_filename
         self.keep_tempfiles = keep_tempfiles
         self.modelfile = FileResource(
@@ -275,7 +269,6 @@ class CRF(BaseEstimator):
         self.verbose = verbose
         self.trainer_cls = trainer_cls
         self.training_log_ = None
-
         self._tagger = None
         self._info_cached = None
 
@@ -330,7 +323,7 @@ class CRF(BaseEstimator):
             if self.verbose:
                 print("")
 
-        trainer.train(self.modelfile.name, holdout=-1 if X_dev is None else 1)
+        trainer.train(self.modelfile.name, int_holdout=(-1 if X_dev is None else 1))
         self.training_log_ = trainer.logparser
         return self
 

--- a/sklearn_crfsuite/metrics.py
+++ b/sklearn_crfsuite/metrics.py
@@ -55,7 +55,7 @@ def flat_fbeta_score(y_true, y_pred, beta, **kwargs):
     Return F-beta score for sequence items.
     """
     from sklearn import metrics
-    return metrics.fbeta_score(y_true, y_pred, beta, **kwargs)
+    return metrics.fbeta_score(y_true, y_pred, beta=beta, **kwargs)
 
 
 @_flattens_y
@@ -64,7 +64,7 @@ def flat_classification_report(y_true, y_pred, labels=None, **kwargs):
     Return classification report for sequence items.
     """
     from sklearn import metrics
-    return metrics.classification_report(y_true, y_pred, labels, **kwargs)
+    return metrics.classification_report(y_true, y_pred, labels=labels, **kwargs)
 
 
 def sequence_accuracy_score(y_true, y_pred):
@@ -76,7 +76,6 @@ def sequence_accuracy_score(y_true, y_pred):
     if not total:
         return 0
 
-    matches = sum(1 for yseq_true, yseq_pred in zip(y_true, y_pred)
-                  if yseq_true == yseq_pred)
+    matches = sum(1 for yseq_true, yseq_pred in zip(y_true, y_pred) if yseq_true == yseq_pred)
 
     return matches / total

--- a/sklearn_crfsuite/metrics.py
+++ b/sklearn_crfsuite/metrics.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division
 from functools import wraps
 
 from sklearn_crfsuite.utils import flatten
@@ -11,6 +9,7 @@ def _flattens_y(func):
         y_true_flat = flatten(y_true)
         y_pred_flat = flatten(y_pred)
         return func(y_true_flat, y_pred_flat, *args, **kwargs)
+
     return wrapper
 
 

--- a/sklearn_crfsuite/scorers.py
+++ b/sklearn_crfsuite/scorers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Scorer functions to use with scikit-learn ``cross_val_score``,
 ``GridSearchCV``, ``RandomizedSearchCV`` and other similar classes.
@@ -6,7 +5,6 @@ Scorer functions to use with scikit-learn ``cross_val_score``,
 from sklearn.metrics import make_scorer
 
 from sklearn_crfsuite import metrics
-
 
 flat_accuracy = make_scorer(metrics.flat_accuracy_score)
 sequence_accuracy = make_scorer(metrics.sequence_accuracy_score)

--- a/sklearn_crfsuite/trainer.py
+++ b/sklearn_crfsuite/trainer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pycrfsuite
 from tabulate import tabulate
 

--- a/sklearn_crfsuite/trainer.py
+++ b/sklearn_crfsuite/trainer.py
@@ -7,6 +7,7 @@ class LinePerIterationTrainer(pycrfsuite.Trainer):
     This pycrfsuite.Trainer prints information about each iteration
     on a single line.
     """
+
     def on_iteration(self, log, info):
         parts = [
             "Iter {num:<3} ",
@@ -39,11 +40,11 @@ class LinePerIterationTrainer(pycrfsuite.Trainer):
                 for entity, score in sorted(last_iter['scores'].items())
             ]
             table = tabulate(data,
-                headers=["Label", "Precision", "Recall", "F1", "Support"],
-                floatfmt="0.3f",
-            )
+                             headers=["Label", "Precision", "Recall", "F1", "Support"],
+                             floatfmt="0.3f",
+                             )
             size = len(table.splitlines()[0])
-            print("="*size)
+            print("=" * size)
             print(table)
-            print("-"*size)
+            print("-" * size)
         super(LinePerIterationTrainer, self).on_optimization_end(log)

--- a/sklearn_crfsuite/utils.py
+++ b/sklearn_crfsuite/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from itertools import chain
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,17 +7,16 @@ def xseq():
         {'walk': 1, 'shop': 0.5},
         {'walk': 1},
         {'walk': 1, 'clean': 0.5},
-        {u'shop': 0.5, u'clean': 0.5},
+        {'shop': 0.5, 'clean': 0.5},
         {'walk': 0.5, 'clean': 1},
-        {'clean': 1, u'shop': 0.1},
+        {'clean': 1, 'shop': 0.1},
         {'walk': 1, 'shop': 0.5},
         {},
         {'clean': 1},
-        {u'солнце': u'не светит'.encode('utf8'), 'clean': 1},
+        {'солнце': 'не светит', 'clean': 1},
     ]
 
 
 @pytest.fixture
 def yseq():
-    return ['sunny', 'sunny', u'sunny', 'rainy', 'rainy', 'rainy',
-            'sunny', 'sunny', 'rainy', 'rainy']
+    return ['sunny', 'sunny', 'sunny', 'rainy', 'rainy', 'rainy', 'sunny', 'sunny', 'rainy', 'rainy']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytest
 
 
@@ -17,6 +15,7 @@ def xseq():
         {'clean': 1},
         {u'солнце': u'не светит'.encode('utf8'), 'clean': 1},
     ]
+
 
 @pytest.fixture
 def yseq():

--- a/tests/test_crf.py
+++ b/tests/test_crf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import pickle
 
@@ -7,8 +6,7 @@ from sklearn.model_selection import cross_val_score
 
 from sklearn_crfsuite import CRF
 
-
-ALGORITHMS =  ["lbfgs", "l2sgd", "pa", "ap", "arow"]
+ALGORITHMS = ["lbfgs", "l2sgd", "pa", "ap", "arow"]
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
@@ -138,7 +136,7 @@ def test_attributes(xseq, yseq):
     assert crf.state_features_ is None
     assert crf.transition_features_ is None
 
-    crf.fit([xseq]*20, [yseq]*20)
+    crf.fit([xseq] * 20, [yseq] * 20)
 
     assert crf.tagger_ is not None
     assert crf.size_ > 1000

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division
-
 import pytest
 
 from sklearn_crfsuite import metrics
-
 
 y1 = [["x", "z", "y"], ["x", "x"]]
 y2 = [["y", "z", "y"], ["x", "y"]]
@@ -41,5 +37,5 @@ def test_flat_f1_score_binary():
 def test_sequence_accuracy():
     assert metrics.sequence_accuracy_score(y1, y2) == 0
     assert metrics.sequence_accuracy_score([], []) == 0
-    assert metrics.sequence_accuracy_score([[1,2], [3], [4]], [[1,2], [4], [4]]) == 2 / 3
-    assert metrics.sequence_accuracy_score([[1,2], [3]], [[1,2], [3]]) == 1.0
+    assert metrics.sequence_accuracy_score([[1, 2], [3], [4]], [[1, 2], [4], [4]]) == 2 / 3
+    assert metrics.sequence_accuracy_score([[1, 2], [3]], [[1, 2], [3]]) == 1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39
 
 [testenv]
 commands=


### PR DESCRIPTION
Remove a few things that are only necessary for Python 2 compatibility

Including:
- six 
- obsolete future imports
- unicode tags and encodings